### PR TITLE
Define background color of body

### DIFF
--- a/themes/calver/css/skeleton.css
+++ b/themes/calver/css/skeleton.css
@@ -125,7 +125,8 @@ body {
   line-height: 1.6;
   font-weight: 400;
   font-family: "Raleway", "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  color: #222; }
+  color: #222; 
+  background: white; }
 
 
 /* Typography


### PR DESCRIPTION
If you have your default background set to black (dark desktop theme), the text on the page was not readable. This additional rule fixes it.