### PR TITLE
[GH-34] link to youtube-dl main site

### DIFF
--- a/entries/overview.md
+++ b/entries/overview.md
@@ -155,7 +155,7 @@ sites. Consider the rapid release cycle of supported services, and it
 becomes clear why the project has adopted CalVer to such a great
 degree.
 
-[youtube_dl]: https://rg3.github.io/youtube-dl/
+[youtube_dl]: https://youtube-dl.org/
 
 ## pytz
 

--- a/entries/overview_zhcn.md
+++ b/entries/overview_zhcn.md
@@ -156,7 +156,7 @@ Twisted 的版本方案已扩展到相关项目，包括：
 快速发布周期，它清楚地说明了
 为什么该项目如此深度的使用 CalVer。
 
-[youtube_dl]: https://rg3.github.io/youtube-dl/
+[youtube_dl]: https://youtube-dl.org/
 
 ## pytz
 


### PR DESCRIPTION
The purpose of bringing up youtube dl was just to showcase. Their main page mentions their latest version which still makes the point. I figure we can at least link to a site that wasn't taken down due to a DCMA takedown notice.
> Latest (v2020.11.01.1) downloads:
